### PR TITLE
mono-xsp4 stop does not detect pid correctly

### DIFF
--- a/debian/mono-xsp4.init
+++ b/debian/mono-xsp4.init
@@ -82,7 +82,7 @@ case "$1" in
 	;;
     stop)
 	log_daemon_msg "Stopping $DESC" "$NAME"
-        for i in $(ps aux | grep -v grep | grep 'xsp4.exe' | cut -c 10-15)
+        for i in $(ps axo pid,command | grep -v grep | grep 'xsp4.exe' | awk '{print $1}')
         do
                 kill $i > /dev/null 2>&1
         done


### PR DESCRIPTION
Running `/etc/init.d/mono-xsp4 stop` does not actually stop the running process because the commands used to detect the PID do not grab the entire PID. In my case (running Ubuntu 20.04), the correct PID being `899` was resolved to `89`:

```
$ ps aux | grep -v grep | grep 'xsp4.exe'
www-data     899  0.1  0.5 286532 41724 ?        Sl   20:23   0:00 /usr/bin/mono /usr/lib/mono/4.5/xsp4.exe --port 8084 --address 0.0.0.0 --appconfigdir /etc/xsp4 --nonstop

$ ps aux | grep -v grep | grep 'xsp4.exe' | cut -c 10-15
    89
```

This fix reworks the command chain to use `awk` instead of `cut` to grab the whole PID.